### PR TITLE
Add type checking specification and examples

### DIFF
--- a/brack-interpreter.txt
+++ b/brack-interpreter.txt
@@ -12,8 +12,28 @@
     
     (parse) <brack_code> → {
         tokenize(brack_code);
+        annotate_type_tokens(tokens);
         build_ast(tokens);
-        validate_syntax(ast)
+        validate_syntax(ast);
+        register_type_annotations(ast)
+    }
+
+    (annotate_type_tokens) <tokens> → {
+        while tokens.has_next {
+            if tokens.peek == '<' {
+                type_token = capture_until('>');
+                label(type_token, type_annotation)
+            }
+            advance(tokens)
+        }
+    }
+
+    (register_type_annotations) <ast> → {
+        traverse_nodes(ast) {
+            if node.has_child(type_annotation) {
+                node.meta.expected_type = normalize_type(node.child(type_annotation))
+            }
+        }
     }
     
     (execute) <ast> → {
@@ -21,7 +41,93 @@
         process_containers → instantiate_modules ||
         process_functions → call_with_params ||
         process_conditionals → evaluate_logic ||
+        process_type_checks → enforce_expected_types ||
         return_outputs
+    }
+
+    (enforce_expected_types) <node> → {
+        if node.command == 'type-check' {
+            expr_value = evaluate(node.args[0]);
+            expected = resolve_expected_type(node.args[1]);
+            actual = infer_type(expr_value);
+            match_types(actual, expected) ?
+                emit([ok expected]) :
+                raise_type_error(expected, actual)
+        }
+    }
+
+    (resolve_expected_type) <type_expr> → {
+        if type_expr.is_metadata {
+            return normalize_type(type_expr)
+        }
+        if type_expr.references_symbol {
+            return lookup_type_symbol(type_expr)
+        }
+        raise_error('unknown-type-annotation', type_expr)
+    }
+
+    (normalize_type) <raw> → {
+        return canonicalize(raw) // ensures `<List<int>>` and `<list <int>>` share structure
+    }
+
+    (infer_type) <value> → {
+        if value.has_meta('type') {
+            return value.meta.type
+        }
+        if value.is_number && value.is_integer {
+            return '<int>'
+        }
+        if value.is_number {
+            return '<float>'
+        }
+        if value.is_boolean {
+            return '<bool>'
+        }
+        if value.is_string {
+            return '<string>'
+        }
+        if value.is_list {
+            element_types = dedupe(map(infer_type, value.items));
+            return element_types.size == 1 ? `<list ${element_types[0]}>` : `<list <any>>`
+        }
+        return '<any>'
+    }
+
+    (match_types) <actual expected> → {
+        if expected == '<any>' {
+            return true
+        }
+        if is_list_type(actual) && is_list_type(expected) {
+            return match_types(inner_list_type(actual), inner_list_type(expected))
+        }
+        return actual == expected
+    }
+
+    (is_list_type) <type_label> → {
+        return type_label.starts_with('<list')
+    }
+
+    (inner_list_type) <type_label> → {
+        return extract_between(type_label, '<list', '>')
+    }
+
+    (extract_between) <text start end> → {
+        sliced = text.remove_prefix(start);
+        return sliced.substring_until(end).trim()
+    }
+
+    (raise_type_error) <expected actual> → {
+        emit({error type-mismatch [expected expected] [actual actual]});
+        halt_current_branch()
+    }
+
+    (type-check) [expr annotated_type] → {
+        expr_value = evaluate(expr);
+        expected = resolve_expected_type(annotated_type);
+        actual = infer_type(expr_value);
+        match_types(actual, expected) ?
+            [ok expected] :
+            {error type-mismatch [expected expected] [actual actual]}
     }
     
     (interpret) <raw_brack> → {

--- a/brack_rosetta.md
+++ b/brack_rosetta.md
@@ -33,6 +33,33 @@ For a formal take on the syntax, consult the EBNF in [`docs/GRAMMAR.md`](docs/GR
 - **`(define [name] <lambda> { ... })`** → Define a function.
 - **`(return [value])`** → Exit function with `value`.
 
+### **Type System Basics**
+Type metadata lives inside angle brackets. When the LLM encounters `<type>` tokens it should treat them as symbolic tags that describe the expected shape of nearby values.
+
+**Primitive tags**
+- `<int>` → Whole numbers (e.g., `0`, `42`, `-9`).
+- `<float>` → Decimal numbers (e.g., `3.14`, `-0.5`).
+- `<string>` → Text wrapped in quotes or bracketed atoms that represent text.
+- `<bool>` → Logical values (`true`, `false`).
+
+**Composite tags**
+- `<list <type>>` → Homogeneous lists (e.g., `<list <int>>` means "a list of integers").
+- `<tuple <type> <type> ...>` → Fixed-length heterogeneous groupings.
+- `<any>` → Explicitly states that any type is acceptable.
+
+### **`(type-check [expr <type>])`**
+- Evaluate or symbolically inspect `expr` in the current environment.
+- Infer the resulting type (or read previously declared metadata).
+- Compare it with `<type>`.
+  - **Match** → Return `[ok <type>]` and continue execution.
+  - **Mismatch** → Return `{error type-mismatch [expected <type>] [actual <inferred-type>]}` and halt or branch as the hosting program dictates.
+
+```brack
+(type-check [sum <int>])        // succeeds if `sum` resolves to an integer
+(type-check [numbers <list <int>>]) // ensures each member of `numbers` is an integer
+(type-check ["oops" <bool>])   // triggers type-mismatch feedback
+```
+
 ---
 
 ## **3. Example: Collaborative Interpretation**

--- a/brack_test.txt
+++ b/brack_test.txt
@@ -63,4 +63,9 @@
 
   // --- Symbolic Meta Example ---
   (print [MetaType of sum: <type-of sum>])
+
+  // --- Type Checking Demo ---
+  (type-check [sum <int>])
+  (type-check [squares <list <int>>])
+  (type-check ["unexpected" <bool>]) // expected to signal a type-mismatch error
 }


### PR DESCRIPTION
## Summary
- describe Brack's primitive and composite type tags in the Rosetta guide
- extend interpreter pseudocode to parse type annotations and validate `(type-check ...)` forms
- add sample programs that demonstrate successful and failing type checks

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68c94f2623bc832686da3893ba843db1